### PR TITLE
Added a Recent Searches tab, where you can see all users searches

### DIFF
--- a/earlybird/main.py
+++ b/earlybird/main.py
@@ -17,6 +17,7 @@ from .db_functions import delete_titles
 from .db_functions import get_profile
 from .db_functions import update_password
 from .db_functions import update_profile
+from .models import Timestamp
 from datetime import timedelta
 from werkzeug.security import generate_password_hash, check_password_hash
 import datetime
@@ -45,6 +46,19 @@ def index():
         return redirect(url_for('main.search'))
     return render_template("index.html")
 
+@main.route('/search_history')
+@login_required
+def search_history():
+    search_history_data = Timestamp.query.order_by(Timestamp.time.desc()).all()
+    unique_search_history_data = []
+    seen_search_terms = set()
+
+    for search in search_history_data:
+        if search.search_term not in seen_search_terms:
+            unique_search_history_data.append(search)
+            seen_search_terms.add(search.search_term)
+
+    return render_template("search_history.html", search_history=unique_search_history_data)
 
 @main.route('/profile', methods=['GET', 'POST'])
 @login_required

--- a/earlybird/templates/base.html
+++ b/earlybird/templates/base.html
@@ -53,6 +53,11 @@
                 {% endif %}
                 {% if current_user.is_authenticated %}
                 <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('main.search_history') }}">Recent Searches</a>
+                </li>
+                {% endif %}
+                {% if current_user.is_authenticated %}
+                <li class="nav-item">
                   <a class="nav-link text-dark" href="{{ url_for('main.profile') }}">
                     <i class="bi bi-person"></i>
                     Profile

--- a/earlybird/templates/search_history.html
+++ b/earlybird/templates/search_history.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>All Users' Search History</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Search Term</th>
+                <th>Date and Time</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for search in search_history %}
+                <tr>
+                    <td>{{ search.search_term }}</td>
+                    <td>{{ search.time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}


### PR DESCRIPTION
Under the "Recent Searches" tab in the navigation bar, display all user's latest unique search without showing duplicate queries.

![image](https://user-images.githubusercontent.com/61632192/233011924-f4844122-7087-4421-a545-7261c3475803.png)
